### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Enables network connection (local and Internet) using the Arduino Ethernet board or shield. For all Arduino boards.
 paragraph=With this library you can use the Arduino Ethernet (shield or board) to connect to Internet. The library provides both Client and server functionalities. The library permits you to connect to a local network also with DHCP and to resolve DNS.
+category=Commnunication
 url=http://arduino.cc/en/Reference/Ethernet
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library Ethernet is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format